### PR TITLE
Remove USM options from SwinIR configs

### DIFF
--- a/SwinIR/1x SwinIR Medium.yml
+++ b/SwinIR/1x SwinIR Medium.yml
@@ -5,11 +5,6 @@ scale: 1
 num_gpu: auto
 manual_seed: 0
 
-# USM the ground-truth #if these are true, it will apply an unsharp mask to the HR images, causing halos on the output
-l1_gt_usm: True
-percep_gt_usm: True
-gan_gt_usm: False
-
 # dataset and data loader settings
 datasets:
   train:

--- a/SwinIR/1x SwinIR Small.yml
+++ b/SwinIR/1x SwinIR Small.yml
@@ -5,11 +5,6 @@ scale: 1
 num_gpu: auto
 manual_seed: 0
 
-# USM the ground-truth #if these are true, it will apply an unsharp mask to the HR images, causing halos on the output
-l1_gt_usm: True
-percep_gt_usm: True
-gan_gt_usm: False
-
 # dataset and data loader settings
 datasets:
   train:


### PR DESCRIPTION
These options are exclusive to Real-ESRGAN models, therefore invalid for SwinIR models.