### PR TITLE
Fix model type of SwinIR configs

### DIFF
--- a/SwinIR/1x SwinIR Medium.yml
+++ b/SwinIR/1x SwinIR Medium.yml
@@ -1,6 +1,6 @@
 # general settings
 name: SwinIRMedium
-model_type: SRGANModel
+model_type: SwinIRModel
 scale: 1
 num_gpu: auto
 manual_seed: 0

--- a/SwinIR/1x SwinIR Small.yml
+++ b/SwinIR/1x SwinIR Small.yml
@@ -1,6 +1,6 @@
 # general settings
 name: SwinIRSmall
-model_type: SRGANModel
+model_type: SwinIRModel
 scale: 1
 num_gpu: auto
 manual_seed: 0


### PR DESCRIPTION
SRGANModel is not what is used in either Redux or original traiNNer, it's SwinIRModel.